### PR TITLE
allow empty card issue date

### DIFF
--- a/paymentexpress/facade.py
+++ b/paymentexpress/facade.py
@@ -71,6 +71,8 @@ class Facade(object):
 
     def _format_card_date(self, str_date):
         # Dirty hack so that Oscar's BankcardForm doesn't need to be overridden
+        if str_date is None:
+            return None
         return str_date.replace('/', '')
 
     def authorise(self, order_number, amount, bankcard):

--- a/paymentexpress/gateway.py
+++ b/paymentexpress/gateway.py
@@ -223,6 +223,7 @@ class Gateway(object):
             if key == 'amount' and value == 0:
                 raise ValueError('Amount must be non-zero')
             if key in ('card_issue_date', 'card_expiry') \
+                and value is not None \
                 and not re.match(r'^(0[1-9]|1[012])([0-9]{2})$', value):
                 raise ValueError('%s must be in format mmyy' % key)
 

--- a/tests/facade_tests.py
+++ b/tests/facade_tests.py
@@ -110,6 +110,16 @@ class FacadeSuccessfulResponseTests(MockedResponseTestCase):
             txn = OrderTransaction.objects.filter(order_number='10001')[0]
             self.assertEquals(AUTH, txn.txn_type)
 
+    def test_empty_issue_date_is_allowed(self):
+        with patch('requests.post') as post:
+            post.return_value = self.create_mock_response(
+                SAMPLE_SUCCESSFUL_RESPONSE)
+            card = Bankcard(card_number=CARD_VISA,
+                            expiry_date='1015',
+                            name="Frankie", cvv="123")
+            txn_ref = self.facade.authorise('1000', 1.23, card)
+            self.assertEquals(self.dps_txn_ref, txn_ref['txn_reference'])
+
 
 class FacadeDeclinedResponseTests(MockedResponseTestCase):
 


### PR DESCRIPTION
- fixed bug where using an empty card issue date will raise an exception because _format_card_date() expects a string
