### PR TITLE
fixed a bug where the wrong billing id is being sent in the request

### DIFF
--- a/paymentexpress/facade.py
+++ b/paymentexpress/facade.py
@@ -118,7 +118,7 @@ class Facade(object):
 
         if billing_id:
             res = self.gateway.purchase(amount=amount,
-                                        billing_id=billing_id,
+                                        dps_billing_id=billing_id,
                                         merchant_ref=merchant_ref)
         elif bankcard:
             card_issue_date = self._format_card_date(bankcard.start_date)

--- a/paymentexpress/gateway.py
+++ b/paymentexpress/gateway.py
@@ -263,7 +263,7 @@ class Gateway(object):
         """
         Purchase - Funds are transferred immediately.
         """
-        if kwargs.get('billing_id') is None:
+        if kwargs.get('dps_billing_id') is None:
             return self._purchase_on_new_card(**kwargs)
         return self._purchase_on_existing_card(**kwargs)
 
@@ -275,7 +275,7 @@ class Gateway(object):
         return self._fetch_response(request)
 
     def _purchase_on_existing_card(self, **kwargs):
-        request = self._get_request(PURCHASE, kwargs, ['billing_id'])
+        request = self._get_request(PURCHASE, kwargs, ['dps_billing_id'])
         return self._fetch_response(request)
 
     def validate(self, **kwargs):

--- a/tests/gateway_tests.py
+++ b/tests/gateway_tests.py
@@ -153,7 +153,7 @@ class ApiResponseTests(MockedResponseTestCase):
                 SAMPLE_SUCCESSFUL_RESPONSE
             )
             self.assertIsInstance(
-                self.gateway.purchase(billing_id='123', amount=1.23), Response
+                self.gateway.purchase(dps_billing_id='123', amount=1.23), Response
             )
 
     def test_purchase_with_bankcard_returns_response(self):

--- a/tests/gateway_tests.py
+++ b/tests/gateway_tests.py
@@ -153,7 +153,8 @@ class ApiResponseTests(MockedResponseTestCase):
                 SAMPLE_SUCCESSFUL_RESPONSE
             )
             self.assertIsInstance(
-                self.gateway.purchase(dps_billing_id='123', amount=1.23), Response
+                self.gateway.purchase(dps_billing_id='123', amount=1.23),
+                Response
             )
 
     def test_purchase_with_bankcard_returns_response(self):


### PR DESCRIPTION
- DpsBillingId is the correct node to use in the request for purchasing on an existing card, not BillingId
